### PR TITLE
Try dockerizing frontend/next.js

### DIFF
--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "aspect_rules_ts", version = "2.2.0")
 bazel_dep(name = "aspect_rules_rollup", version = "1.0.2")
 bazel_dep(name = "aspect_rules_webpack", version = "0.14.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "rules_oci", version = "1.7.5")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm", dev_dependency = True)
 use_repo(pnpm, "pnpm")
@@ -34,3 +35,14 @@ rules_ts_ext = use_extension(
 )
 rules_ts_ext.deps()
 use_repo(rules_ts_ext, "npm_typescript")
+
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+
+oci.pull(
+    name = "debian_node",
+    image = "node:20-slim",
+    platforms = [
+        "linux/amd64",
+    ],
+)
+use_repo(oci, "debian_node")

--- a/frontend/next.js/BUILD.bazel
+++ b/frontend/next.js/BUILD.bazel
@@ -1,8 +1,9 @@
-load("@aspect_rules_js//js:defs.bzl", "js_library", "js_test")
+load("@aspect_rules_js//js:defs.bzl", "js_library", "js_test", "js_image_layer")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//next.js:next/package_json.bzl", next_bin = "bin")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 load("//next.js:defs.bzl", "next")
 
 npm_link_all_packages(name = "node_modules")
@@ -79,4 +80,26 @@ build_test(
         # TODO: fix in Next.js (https://github.com/vercel/next.js/issues/43344) or find work-around.
         # ":next_export",
     ],
+)
+
+js_image_layer(
+    name = "layers",
+    binary = ":next_start",
+    root = "/app",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_node",
+    cmd = ["/app/next.js/next_start"],
+    entrypoint = ["/bin/bash"],
+    tars = [
+        ":layers",
+    ],
+)
+
+oci_tarball(
+    name = "image_tarball",
+    image = ":image",
+    repo_tags = ["examples_nextjs:latest"],
 )


### PR DESCRIPTION
With these additions, I'm able to build the image:

```
$ bazel run //next.js:image_tarball
INFO: Analyzed target //next.js:image_tarball (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //next.js:image_tarball up-to-date:
  bazel-bin/next.js/image_tarball/tarball.tar
INFO: Elapsed time: 0.123s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/next.js/image_tarball.sh
Loaded image: examples_nextjs:latest
```

But the runner script fails:

```
$ docker run -it  examples_nextjs:latest
/app/next.js/next_start.runfiles/_main/next.js/next_start.sh: line 451: cd: next.js: No such file or directory
```