### PR TITLE
Fixup

### DIFF
--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "aspect_rules_ts", version = "2.2.0")
 bazel_dep(name = "aspect_rules_rollup", version = "1.0.2")
 bazel_dep(name = "aspect_rules_webpack", version = "0.14.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "rules_oci", version = "1.7.5")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm", dev_dependency = True)
@@ -43,6 +44,14 @@ oci.pull(
     image = "node:20-slim",
     platforms = [
         "linux/amd64",
+        "linux/arm64/v8",
     ],
 )
 use_repo(oci, "debian_node")
+
+node = use_extension(
+    "@rules_nodejs//nodejs:extensions.bzl",
+    "node",
+    dev_dependency = True,
+)
+use_repo(node, "nodejs_toolchains")

--- a/frontend/next.js/BUILD.bazel
+++ b/frontend/next.js/BUILD.bazel
@@ -82,16 +82,57 @@ build_test(
     ],
 )
 
+platform(
+    name = "linux_amd64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+next_bin.next_binary(
+    name = "next_js_start",
+    fixed_args = ["start"],
+    chdir = package_name(),
+    data = [
+        "//next.js/pages",
+        "//next.js/public",
+        "//next.js/styles",
+        ":next",
+        "next.config.js",
+        "package.json",
+        ":node_modules/@bazel-example/one",
+        ":node_modules/is-even",
+        ":node_modules/next",
+        ":node_modules/react",
+        ":node_modules/react-dom",
+        ":node_modules/typescript",
+    ],
+)
+
 js_image_layer(
     name = "layers",
-    binary = ":next_start",
+    binary = ":next_js_start",
+    platform = select({
+        "@platforms//cpu:arm64": ":linux_arm64",
+        "@platforms//cpu:x86_64": ":linux_amd64",
+    }),
     root = "/app",
 )
 
 oci_image(
     name = "image",
     base = "@debian_node",
-    cmd = ["/app/next.js/next_start"],
+    cmd = ["/app/next.js/next_js_start"],
+    workdir = "/app/next.js/next_js_start.runfiles/_main",
     entrypoint = ["/bin/bash"],
     tars = [
         ":layers",


### PR DESCRIPTION
On MacOS, bzlmod node toolchains have a bug for transitions so to build the image with the correct node toolchain you need add `--extra_toolchains`:

```
bazel run //next.js:image_tarball --extra_toolchains=@nodejs_toolchains//:linux_arm64_toolchain_target
```

That followed by

```
docker run -it -p 3000:3000 examples_nextjs:latest
```

should start the webserver